### PR TITLE
Improves event log formatting in cloudwatch logs

### DIFF
--- a/Lesson-1-restricted-access/lesson1lambda.py
+++ b/Lesson-1-restricted-access/lesson1lambda.py
@@ -1,13 +1,12 @@
 import boto3
 iam = boto3.resource('iam')
-# import json ## uncomment this, if you are wanting to enable debug.
 
 denyPolicyArn = 'POLICYARN::REPLACEME'
 adminGroup = 'iamadmins'
 
 def lambda_handler( event, context ):
 	# print("Event data:")
-	# print( json.dumps( event, sort_keys=True, indent=4, separators=(',', ': ') ) ) ## you will need import json above also.
+	# print(event)
 
 	if event["detail"]["userIdentity"]["type"] != 'IAMUser': # Test if the user type is IAM:
 		print('User is not an IAMUser. Done.')


### PR DESCRIPTION
Outputs event json as a single line, which allows the cloudwatch logs
console to pretty-print the json event data

with change: 
<img width="924" alt="after" src="https://cloud.githubusercontent.com/assets/41758/25443732/51780aa0-2a6e-11e7-8683-024fa1fdc6c7.png">

without change:
<img width="553" alt="before" src="https://cloud.githubusercontent.com/assets/41758/25443891/d9e7332a-2a6e-11e7-8d11-823ff9cd6555.png">
